### PR TITLE
Update rfg-api dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "bluebird": "3.*",
     "commander": "^2.9.0",
     "glob": "6.*",
-    "rfg-api": "^0.1.3"
+    "rfg-api": "^0.3.0"
   }
 }


### PR DESCRIPTION
Fix hang issue in unzip dependency of rfg-api by switching to unzip2 in new version.